### PR TITLE
Spelling correction and Instance comparision updated

### DIFF
--- a/src/Traits/CanRate.php
+++ b/src/Traits/CanRate.php
@@ -77,7 +77,7 @@ trait CanRate
         }
 
         if (! $this->hasRated($model)) {
-            return $this->rate($mode, $newRating);
+            return $this->rate($model, $newRating);
         }
 
         $this->unrate($model);

--- a/src/Traits/CanRate.php
+++ b/src/Traits/CanRate.php
@@ -2,8 +2,8 @@
 
 namespace Rennokki\Rating\Traits;
 
+use Rennokki\Rating\Contracts\Rateable;
 use Rennokki\Rating\Contracts\Rater;
-use Rennokki\Rating\Contracts\Rating;
 
 trait CanRate
 {
@@ -29,7 +29,7 @@ trait CanRate
      */
     public function hasRated($model): bool
     {
-        if (! $model instanceof Rater && ! $model instanceof Rating) {
+        if (! $model instanceof Rater && ! $model instanceof Rateable) {
             return false;
         }
 
@@ -40,12 +40,12 @@ trait CanRate
      * Rate a certain model.
      *
      * @param Model $model The model which will be rated.
-     * @param float $rate The rate amount.
+     * @param float $rating The rate amount.
      * @return bool
      */
     public function rate($model, $rating): bool
     {
-        if (! $model instanceof Rater && ! $model instanceof Rating) {
+        if (! $model instanceof Rater && ! $model instanceof Rateable) {
             return false;
         }
 
@@ -67,12 +67,12 @@ trait CanRate
      * Rate a certain model.
      *
      * @param Model $model The model which will be rated.
-     * @param float $rate The rate amount.
+     * @param float $newRating The rate amount.
      * @return bool
      */
     public function updateRatingFor($model, $newRating): bool
     {
-        if (! $model instanceof Rater && ! $model instanceof Rating) {
+        if (! $model instanceof Rater && ! $model instanceof Rateable) {
             return false;
         }
 


### PR DESCRIPTION
There was incorrect parameter documentation in rate() and updateRatingFor() function.

### First Issue

**rate()** docs:

`     * @param float $rate The rate amount.`

Since parameter is `$rating`, there was `$rate` in the docs

Similary in the **updateRatingFor()** function 

`     * @param float $rate The rate amount.`

Since parameter is `$newRating`, there was `$rate` in the docs.

### Second Issue

Another thing is, Inside **rate**, **updateRatingFor** and **unrate** function model is checked with instance of **Rating** which will always return false since we implement `Rater` or `Rateable` in the model.

### Third Issue

In the updateRatingFor function, there is a type in the variable `$mode`. It should be `$model`